### PR TITLE
Add branch protection workflow

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -1,0 +1,23 @@
+name: Branch Protection Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-branch-protection:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check branch protection
+        run: |
+          if [[ "${{ github.base_ref }}" == "main" ]]; then
+            echo "Pull request targets main branch - requiring review"
+            if [[ "${{ github.event.pull_request.requested_reviewers }}" == "[]" ]]; then
+              echo "Error: Pull request must have at least one reviewer assigned"
+              exit 1
+            fi
+          fi


### PR DESCRIPTION
This PR adds branch protection through GitHub Actions workflow.

Changes include:
1. A new GitHub Actions workflow that enforces:
   - Pull requests must be created for changes to main branch
   - At least one reviewer must be assigned
   
To complete the setup, after merging this PR, please:
1. Go to repository Settings > Branches
2. Click 'Add branch protection rule'
3. Set the following:
   - Branch name pattern: `main`
   - Check 'Require pull request reviews before merging'
   - Check 'Require review from Code Owners'
   - Check 'Include administrators'
   - Check 'Restrict who can push to matching branches'

This will ensure that:
- No direct pushes to main branch
- Pull requests require your review
- Branch protection rules apply to everyone, including administrators